### PR TITLE
Add Alt/Az and pier side metadata to averaged images

### DIFF
--- a/getAstroCamShot.js
+++ b/getAstroCamShot.js
@@ -1,6 +1,6 @@
 /*
     getAstroCamShot.js
-    (c) by Boris Emchenko 2021
+    (c) by Boris Emchenko 2021-2025
     http://astromania.info
     
     Script for creating combined (integrated) image from WyzeCam v3 RTSP stream
@@ -17,6 +17,12 @@
     2) GraphicsMagick package
     ftp://ftp.graphicsmagick.org/pub/GraphicsMagick/
     tested with 1.3.36-Q16
+
+    v 2.1 [2025-08-30]
+    - also write PierSide to filename
+
+    v 2.0 [2025-08-29]
+    - read Alt Az and write it to filename
 
     v 1.2 [2021-11-05]
     - path for out images

--- a/getAstroCamShot.js
+++ b/getAstroCamShot.js
@@ -43,6 +43,7 @@ var TEMP_IMAGE_DIR="e:\\AllSky\\tmpimages\\";                                   
 var TEMP_IMAGE_PREFIX = "do_";
 var OUT_FILENAME_PATH = "e:\\AllSky\\frames\\";                                            			// mandatory  "/" at the end
 var OUT_FILENAME_PREFIX = "AstroCam_";
+var ASCOM_TELESCOPE_PROGID = "EQMOD.Telescope";
 
 var silentMode = true;                                                                  // prevent any messages
 var Number_Of_Frames_to_Get = 25;                                                       // number of frames to capture
@@ -71,7 +72,15 @@ function loadImages()
 function averageImages()
 {
    var ts = formatDateTime(new Date());
-   var Out_File_Name = OUT_FILENAME_PATH + OUT_FILENAME_PREFIX + ts + ".jpg";
+   var coords = getTelescopeAltAz();
+   var coordText = "";
+   var sideText = "";
+   if (coords) {
+       coordText = "_az_" + formatDegMin(coords.az, 3) + "_alt_" + formatDegMin(coords.alt, 2);
+       if (coords.side)
+           sideText = "_" + coords.side;
+   }
+   var Out_File_Name = OUT_FILENAME_PATH + OUT_FILENAME_PREFIX + ts + coordText + sideText + ".jpg";
    
    //"c:\Program Files\GraphicsMagick-1.3.36-Q16\gm.exe" convert -average tmpimages\do_*.jpg avg.jpg
    st="\"" + IMAGE_MAGIC_PATH + "\" convert -average " + TEMP_IMAGE_DIR + TEMP_IMAGE_PREFIX + "*.jpg " + Out_File_Name;
@@ -173,6 +182,51 @@ function clearImages()
 
    st = "";
    logger("Repeating images deleted: " + fileDeleteCount);
+}
+
+/**********************************************************************
+ * Get Alt/Az coordinates from ASCOM mount
+ **********************************************************************/
+function getTelescopeAltAz()
+{
+    try {
+        var telescope = new ActiveXObject(ASCOM_TELESCOPE_PROGID);
+        telescope.Connected = true;
+        var alt = telescope.Altitude;
+        var az = telescope.Azimuth;
+        var side = "";
+        try {
+            var pier = telescope.SideOfPier;
+            var pierStr = ("" + pier).toLowerCase();
+            // SideOfPier returns the mount side, so swap to get pointing direction
+            if (pier == 0 || pierStr.indexOf("east") != -1)
+                side = "W"; // mount east of pier -> pointing west
+            else if (pier == 1 || pierStr.indexOf("west") != -1)
+                side = "E"; // mount west of pier -> pointing east
+        } catch (e1) {
+        }
+        telescope.Connected = false;
+        return {alt: alt, az: az, side: side};
+    }
+    catch (e) {
+        logger("ASCOM connection failed: " + e.message);
+        return null;
+    }
+}
+
+/**********************************************************************
+ * Format degrees to DEG-MIN string
+ **********************************************************************/
+function formatDegMin(value, padDeg)
+{
+    var sign = value < 0 ? "-" : "";
+    value = Math.abs(value);
+    var deg = Math.floor(value);
+    var minutes = Math.round((value - deg) * 60);
+    if (minutes == 60) { minutes = 0; deg += 1; }
+    var degStr = ("000" + deg).slice(-padDeg);
+    var minStr = ("0" + minutes).slice(-2);
+    return sign + degStr + "-" + minStr;
 }
 
 /**********************************************************************


### PR DESCRIPTION
## Summary
- connect to EQMOD telescope via ASCOM to retrieve Alt/Az coordinates and mount side
- append formatted coordinates and pier side letters to averaged image filenames
- map ASCOM SideOfPier values to the telescope's pointing direction (E/W)

## Testing
- `node --check getAstroCamShot.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1c32718c083258809ea5214f93012