### PR TITLE
Add Alt/Az and pier side metadata to averaged images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WyzeAstrocam
 
 getAstroCamShot.js & makeAVI.js  
-(c) by Boris Emchenko 2021-2022
+(c) by Boris Emchenko 2021-2025
 
 Script for creating a combined (integrated) image from a WyzeCam v3 RTSP stream.  
 Prerequisites: the WyzeCam must be flashed with the official beta firmware to enable RTSP streaming.
@@ -69,7 +69,7 @@ Required software:
 ## Version history
 
 ### getAstroCamShot.js
-- v1.3 [2025-08-30] - connect to ASCOM telescope to append Alt/Az coordinates and pier side letters to filenames
+- v2.0 [2025-08-30] - connect to ASCOM telescope to append Alt/Az coordinates and pier side letters to filenames
 - v1.2 [2021-11-05] - path for output images and command line parameters for debug output
 - v1.1 [2021-11-02] - check if temp image folder exists and create it
 - v1.0 [2021-11-01] - tested working release

--- a/README.md
+++ b/README.md
@@ -1,41 +1,41 @@
 # WyzeAstrocam
 
-    getAstroCamShot.js & makeAVI.js
-    (c) by Boris Emchenko 2021-2022
-    
-    Script for creating combined (integrated) image from WyzeCam v3 RTSP stream
-	Prerequests: WyzeCam need to be flashed with special (official beta) firmware to have RTSP streaming available
-    
-    1) Get N frames, save it to disk
-    2) Check if they are different
-    3) Combine them (by averaging) into one final frame
-	4) Make avi from final frames
+getAstroCamShot.js & makeAVI.js  
+(c) by Boris Emchenko 2021-2022
 
-    Need to install:
-    1) ffmpeg package  
-    Zeranoe FFmpeg Builds <http://ffmpeg.zeranoe.com/builds/>
-    tested with build: ffmpeg-20200424-a501947-win64-static
+Script for creating a combined (integrated) image from a WyzeCam v3 RTSP stream.  
+Prerequisites: the WyzeCam must be flashed with the official beta firmware to enable RTSP streaming.
 
-    2) GraphicsMagick package
-    ftp://ftp.graphicsmagick.org/pub/GraphicsMagick/
-    tested with 1.3.36-Q16
+1) Capture N frames and save them to disk.  
+2) Check that the frames are different.  
+3) Combine them by averaging into one final frame.  
+4) Make an AVI from the final frames.
 
-	3) If you want to run tasks based on sunrise/sunset events, you may need Sunwait utility
-	https://sourceforge.net/projects/sunwait4windows/
-	Then you should use version of utilities with "on sunrise" suffix in task scheduler
+Required software:
+1) ffmpeg package  
+   Zeranoe FFmpeg Builds <http://ffmpeg.zeranoe.com/builds/>  
+   tested with build: ffmpeg-20200424-a501947-win64-static
+
+2) GraphicsMagick package  
+   ftp://ftp.graphicsmagick.org/pub/GraphicsMagick/  
+   tested with 1.3.36-Q16
+
+3) If you want to run tasks based on sunrise/sunset events, you may need the Sunwait utility:  
+   https://sourceforge.net/projects/sunwait4windows/  
+   Use the versions of utilities with the "on sunrise" suffix in the task scheduler.
 
 
 	Utilities:
-	1) getAstroCamShot.js
-		- script for creating combined (integrated) image from WyzeCam v3 RTSP stream
-			1) Get N frames, save it to disk
-			2) Check if they are different
-			3) Combine them (by averaging)
-	2) makeAVI.js
-		- script for creating timelapse video from images grabbed from WyzeCam v3 RTSP stream
-			1) Copy images to avitempfolder and rename them (0001 - 9999), so ffmpeg could work with them
-			2) Make video from individual frames (ffmpeg)
-			If file AstroCam_overlay.png found it would be overlayed over movie
+        1) getAstroCamShot.js
+                - script for creating combined (integrated) images from a WyzeCam v3 RTSP stream
+                        1) Capture N frames and save them to disk
+                        2) Check that the frames are different
+                        3) Combine them by averaging
+        2) makeAVI.js
+                - script for creating timelapse video from images grabbed from WyzeCam v3 RTSP stream
+                        1) Copy images to avitempfolder and rename them (0001 - 9999), so ffmpeg could work with them
+                        2) Make video from individual frames (ffmpeg)
+                        If AstroCam_overlay.png is found it will be overlaid on the movie
 			
 	Other files:
 	"On sunrise" version blocks running until sunrise|sunset events (for use with task schedule)
@@ -43,27 +43,38 @@
 		- bat wrapper for getAstroCamShot.js
 	2) makeAVI.bat | makeAVI_on_sunrise.bat
 		- bat wrapper for makeAVI.js
-	3) archiveImages.bat | archiveImages_on_sunrise.bat	
-		- upload avi and moves avi frames to archive. 
+        3) archiveImages.bat | archiveImages_on_sunrise.bat
+                - uploads the AVI and moves frames to the archive
 	4) list_events.bat
 		- list run times for current day 
 
 	For debug purposes only:
-	1) get_wyze_image.bat
-		- bat file for debuging saving images from camera
-	2) sum_images.bat
-		- bat file for debuging combining images
+        1) get_wyze_image.bat
+                - batch file for debugging image captures from the camera
+        2) sum_images.bat
+                - batch file for debugging image combination
 
 
 	Using TASK SCHEDULER
 	
-	Recommended to create 3 task:
-	1) Run getAstroCamShot.js (or getAstroCamShot_sunevents.bat) as often as you wish (be carefull not to run too frequently) from till  you need it 
+        Recommended to create three tasks:
+        1) Run getAstroCamShot.js (or getAstroCamShot_sunevents.bat) as often as you wish (be careful not to run too frequently) from till you need it
 		example - timelapse_taskmanager.xml
 		advice: Task should be run like this: "cmd" and parameters "/c start /min "WyzeCam" D:\ASCOMscripts\WyzeAstrocam\getAstroCamShot_sunevents.bat ^& exit" - then program will start minimized
-	2) Run makeAVI.js (or makeAVI_on_sunrise.bat) when you want to create AVI from the files, that are present in image folder at this moment. I run it after task 1 stops running (in morning)
+        2) Run makeAVI.js (or makeAVI_on_sunrise.bat) when you want to create an AVI from the files that are present in the image folder at that moment. Run it after task 1 stops (in the morning)
 		example - timelapse_makeavi_taskmanager.xml
-	3) Run archiveImages (or archiveImages_on_sunrise.bat) after task 2 finishing to move frames to archive folder. Or just delete them
-		example - timelapse_archiveimages_taskmanager.xml
-	
-	
+        3) Run archiveImages (or archiveImages_on_sunrise.bat) after task 2 finishes to move frames to the archive folder, or just delete them
+                example - timelapse_archiveimages_taskmanager.xml
+
+## Version history
+
+### getAstroCamShot.js
+- v1.3 [2025-08-30] - connect to ASCOM telescope to append Alt/Az coordinates and pier side letters to filenames
+- v1.2 [2021-11-05] - path for output images and command line parameters for debug output
+- v1.1 [2021-11-02] - check if temp image folder exists and create it
+- v1.0 [2021-11-01] - tested working release
+
+### makeAVI.js
+- v2.0 [2023-10-15] - Keogram creation
+- v1.0 [2021-11-06] - tested working release
+

--- a/getAstroCamShot.js
+++ b/getAstroCamShot.js
@@ -1,6 +1,6 @@
 /*
     getAstroCamShot.js
-    (c) by Boris Emchenko 2021
+    (c) by Boris Emchenko 2021-2025
     http://astromania.info
     
     Script for creating combined (integrated) image from WyzeCam v3 RTSP stream
@@ -18,7 +18,7 @@
     ftp://ftp.graphicsmagick.org/pub/GraphicsMagick/
     tested with 1.3.36-Q16
 
-    v 1.3 [2025-08-30]
+    v 2.0 [2025-08-30]
     - connect to ASCOM telescope to append Alt/Az coordinates and pier side letters to filenames
 
     v 1.2 [2021-11-05]
@@ -34,23 +34,27 @@
 
     Command line parameters:
     -debug or -verbose: output messages (better to use in cscript mode)
-   
 
 */
 
 //Options initialization
-var RTSP_URL="rtsp://borise:astrotest@192.168.2.112/live";
-var FFMPEG_PATH= "e:\\Miscellaneous\\ffmpeg\\bin\\ffmpeg.exe";
-var IMAGE_MAGIC_PATH= "c:\\Program Files\\GraphicsMagick-1.3.36-Q16\\gm.exe";
-var TEMP_IMAGE_DIR="e:\\AllSky\\tmpimages\\";                                                       // mandatory  "/" at the end
-var TEMP_IMAGE_PREFIX = "do_";
-var OUT_FILENAME_PATH = "e:\\AllSky\\frames\\";                                            			// mandatory  "/" at the end
-var OUT_FILENAME_PREFIX = "AstroCam_";
-var ASCOM_TELESCOPE_PROGID = "EQMOD.Telescope";
+var SCRIPT_VERSION            = "2.0";
+var SCRIPT_DATE               = "2025-08-30";
+var RTSP_URL                  = "rtsp://borise:astrotest@192.168.2.112/live";
+var FFMPEG_PATH               = "e:\\Miscellaneous\\ffmpeg\\bin\\ffmpeg.exe";
+var IMAGE_MAGIC_PATH          = "c:\\Program Files\\GraphicsMagick-1.3.36-Q16\\gm.exe";
+var TEMP_IMAGE_DIR            = "e:\\AllSky\\tmpimages\\";                                   // mandatory  "/" at the end
+var TEMP_IMAGE_PREFIX         = "do_";
+var OUT_FILENAME_PATH         = "e:\\AllSky\\frames\\";                                      // mandatory  "/" at the end
+var OUT_FILENAME_PREFIX       = "AstroCam_";
 
-var silentMode = true;                                                                  // prevent any messages
-var Number_Of_Frames_to_Get = 25;                                                       // number of frames to capture
-var Frame_Rate = 2;                                                                     // ffmpeg capturing frame rate
+var ASCOM_TELESCOPE_PROGID    = "EQMOD.Telescope";
+
+var Number_Of_Frames_to_Get = 25;                                                            // number of frames to capture
+var Frame_Rate = 2;                                                                          // ffmpeg capturing frame rate
+
+var silentMode = true;                                                                       // prevent any messages
+
 
 //Initialization    
 var WshShell = new ActiveXObject("WScript.Shell");
@@ -287,6 +291,7 @@ function parseCommandLineParameters()
 function headerOutput()
 {
     logger("getAstroCamShot script");
+    logger("version " + SCRIPT_VERSION + " from " + SCRIPT_DATE);
     logger("Camera url: " + RTSP_URL);
     logger("Using verbose mode");            
     logger("");

--- a/getAstroCamShot.js
+++ b/getAstroCamShot.js
@@ -18,6 +18,9 @@
     ftp://ftp.graphicsmagick.org/pub/GraphicsMagick/
     tested with 1.3.36-Q16
 
+    v 1.3 [2025-08-30]
+    - connect to ASCOM telescope to append Alt/Az coordinates and pier side letters to filenames
+
     v 1.2 [2021-11-05]
     - path for out images
     - command line parameters for debug output
@@ -43,6 +46,7 @@ var TEMP_IMAGE_DIR="e:\\AllSky\\tmpimages\\";                                   
 var TEMP_IMAGE_PREFIX = "do_";
 var OUT_FILENAME_PATH = "e:\\AllSky\\frames\\";                                            			// mandatory  "/" at the end
 var OUT_FILENAME_PREFIX = "AstroCam_";
+var ASCOM_TELESCOPE_PROGID = "EQMOD.Telescope";
 
 var silentMode = true;                                                                  // prevent any messages
 var Number_Of_Frames_to_Get = 25;                                                       // number of frames to capture
@@ -71,7 +75,15 @@ function loadImages()
 function averageImages()
 {
    var ts = formatDateTime(new Date());
-   var Out_File_Name = OUT_FILENAME_PATH + OUT_FILENAME_PREFIX + ts + ".jpg";
+   var coords = getTelescopeAltAz();
+   var coordText = "";
+   var sideText = "";
+   if (coords) {
+       coordText = "_az_" + formatDegMin(coords.az, 3) + "_alt_" + formatDegMin(coords.alt, 2);
+       if (coords.side)
+           sideText = "_" + coords.side;
+   }
+   var Out_File_Name = OUT_FILENAME_PATH + OUT_FILENAME_PREFIX + ts + coordText + sideText + ".jpg";
    
    //"c:\Program Files\GraphicsMagick-1.3.36-Q16\gm.exe" convert -average tmpimages\do_*.jpg avg.jpg
    st="\"" + IMAGE_MAGIC_PATH + "\" convert -average " + TEMP_IMAGE_DIR + TEMP_IMAGE_PREFIX + "*.jpg " + Out_File_Name;
@@ -173,6 +185,51 @@ function clearImages()
 
    st = "";
    logger("Repeating images deleted: " + fileDeleteCount);
+}
+
+/**********************************************************************
+ * Get Alt/Az coordinates from ASCOM mount
+ **********************************************************************/
+function getTelescopeAltAz()
+{
+    try {
+        var telescope = new ActiveXObject(ASCOM_TELESCOPE_PROGID);
+        telescope.Connected = true;
+        var alt = telescope.Altitude;
+        var az = telescope.Azimuth;
+        var side = "";
+        try {
+            var pier = telescope.SideOfPier;
+            var pierStr = ("" + pier).toLowerCase();
+            // SideOfPier returns the mount side, so swap to get pointing direction
+            if (pier == 0 || pierStr.indexOf("east") != -1)
+                side = "W"; // mount east of pier -> pointing west
+            else if (pier == 1 || pierStr.indexOf("west") != -1)
+                side = "E"; // mount west of pier -> pointing east
+        } catch (e1) {
+        }
+        telescope.Connected = false;
+        return {alt: alt, az: az, side: side};
+    }
+    catch (e) {
+        logger("ASCOM connection failed: " + e.message);
+        return null;
+    }
+}
+
+/**********************************************************************
+ * Format degrees to DEG-MIN string
+ **********************************************************************/
+function formatDegMin(value, padDeg)
+{
+    var sign = value < 0 ? "-" : "";
+    value = Math.abs(value);
+    var deg = Math.floor(value);
+    var minutes = Math.round((value - deg) * 60);
+    if (minutes == 60) { minutes = 0; deg += 1; }
+    var degStr = ("000" + deg).slice(-padDeg);
+    var minStr = ("0" + minutes).slice(-2);
+    return sign + degStr + "-" + minStr;
 }
 
 /**********************************************************************


### PR DESCRIPTION
## Summary
- connect to EQMOD telescope via ASCOM to retrieve Alt/Az coordinates and mount side
- append formatted coordinates and pier side letters to averaged image filenames
- map ASCOM SideOfPier values to the telescope's pointing direction (E/W)
- document version history and clean up README grammar

## Testing
- `node --check getAstroCamShot.js`
- `node --check makeAVI.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1c32718c083258809ea5214f93012