### PR TITLE
Use RegExp for filename parsing

### DIFF
--- a/makeAVI.js
+++ b/makeAVI.js
@@ -100,9 +100,15 @@ function prepareImageFolder()
 		f = fc.item();
         var oldFileName = f.Name;
         if (j==1) {
-            var result = oldFileName.match('(' + OUT_FILENAME_PREFIX + '(\\d+)-(\\d+)-(\\d+))_(.*).jpg');
-            OutBaseName = result[1];
-        } 
+            var regex = new RegExp('(' + OUT_FILENAME_PREFIX + '(\\d+)-(\\d+)-(\\d+))_(.*)\\.jpg');
+            var result = oldFileName.match(regex);
+            if (result) {
+                OutBaseName = result[1];
+            } else {
+                logger('Filename [' + oldFileName + '] does not match expected pattern');
+                continue;
+            }
+        }
         var newFileName = OutBaseName + "_" +  padNumber(j, 4) +".jpg";
         //logger("["+newFileName+"]");
         //f.Name = newFileName;


### PR DESCRIPTION
## Summary
- use a proper RegExp with escaped dot when parsing image filenames
- guard against filenames that do not match the expected pattern

## Testing
- `node makeAVI.js` *(fails: ActiveXObject is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c26ec9c08325b1572dbfa359858a