### PR TITLE
Declare loop counters locally

### DIFF
--- a/getAstroCamShot.js
+++ b/getAstroCamShot.js
@@ -126,8 +126,8 @@ function prepareImageFolder()
     
     folder = objFS.GetFolder(TEMP_IMAGE_DIR);
    
-	fc = new Enumerator(folder.files);
-    i=0;
+        fc = new Enumerator(folder.files);
+    var i=0;
 
 	for (; !fc.atEnd(); fc.moveNext())
 	{

--- a/makeAVI.js
+++ b/makeAVI.js
@@ -79,7 +79,7 @@ function prepareImageFolder()
         folder = objFS.GetFolder(AVI_TEMPIMAGES_PATH);
        
         fc = new Enumerator(folder.files);
-        i=0;
+        var i=0;
 
         for (; !fc.atEnd(); fc.moveNext())
         {
@@ -93,8 +93,8 @@ function prepareImageFolder()
     // Copy all files to temp folder
     folder = objFS.GetFolder(OUT_FILENAME_PATH);
    
-	fc = new Enumerator(folder.files);
-    j=1;
+        fc = new Enumerator(folder.files);
+    var j=1;
 	for (; !fc.atEnd(); fc.moveNext())
 	{
 		f = fc.item();
@@ -125,8 +125,8 @@ function prepareImageFolder()
 			//delete all files in temp folder
 			folder = objFS.GetFolder(KEO_TEMP_FOLDER);
 		   
-			fc = new Enumerator(folder.files);
-			i=0;
+                        fc = new Enumerator(folder.files);
+                        var i=0;
 
 			for (; !fc.atEnd(); fc.moveNext())
 			{


### PR DESCRIPTION
## Summary
- Scope temporary counters `i` and `j` with `var` in timelapse preparation
- Scope keogram cleanup counter `i` locally to avoid unintended globals
- Scope image folder cleanup counter `i` in snapshot script

## Testing
- `node --check makeAVI.js`
- `node --check getAstroCamShot.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2c2b50b34832590817a132eb71470