### PR TITLE
Declare global KEOGRAM_FILE variable

### DIFF
--- a/makeAVI.js
+++ b/makeAVI.js
@@ -49,6 +49,7 @@ var objFS = new ActiveXObject("Scripting.FileSystemObject");
 
 var OutBaseName = "";   // would be calculated further
 var AVI_FILE = "";      // would be calculated further. Name of avi file begins with OUT_FILENAME_PREFIX and date of the first frame, i.e. "AstroCam_2021-11-05.mp4"
+var KEOGRAM_FILE = "";   // would be calculated further
 
 /**********************************************************************
  * Check if temp image folder exists


### PR DESCRIPTION
## Summary
- Declare KEOGRAM_FILE at the top-level
- Ensure keogram generation uses the declared variable

## Testing
- `node --check makeAVI.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2c2b8879083259e145b1481867257