### PR TITLE
Use local variables for command strings

### DIFF
--- a/getAstroCamShot.js
+++ b/getAstroCamShot.js
@@ -71,7 +71,7 @@ function loadImages()
 {
    // -timelimit 20
    //"d:\Miscellaneous\#App\ffmpeg\bin\ffmpeg.exe" -y -loglevel verbose -stimeout 3000000 -rtsp_transport tcp -i rtsp://boris:astrotest@192.168.1.241/live -frames:v 100 -q:v 2 -r 10 -bufsize 500K -maxrate 1M tmpimages\do_%%d.jpg 
-   st="\"" + FFMPEG_PATH + "\" -y -loglevel verbose -stimeout 3000000 -timelimit 20 -rtsp_transport tcp -i " + RTSP_URL + " -frames:v " + Number_Of_Frames_to_Get+ " -q:v 2 -r " + Frame_Rate + " -bufsize 500K -maxrate 1M " + TEMP_IMAGE_DIR + TEMP_IMAGE_PREFIX + "%d.jpg";
+    var st = "\"" + FFMPEG_PATH + "\" -y -loglevel verbose -stimeout 3000000 -timelimit 20 -rtsp_transport tcp -i " + RTSP_URL + " -frames:v " + Number_Of_Frames_to_Get+ " -q:v 2 -r " + Frame_Rate + " -bufsize 500K -maxrate 1M " + TEMP_IMAGE_DIR + TEMP_IMAGE_PREFIX + "%d.jpg";
    logger(st);
    WshShell.Run (st,7, true);
 }
@@ -94,7 +94,7 @@ function averageImages()
    var Out_File_Name = OUT_FILENAME_PATH + OUT_FILENAME_PREFIX + ts + coordText + sideText + ".jpg";
    
    //"c:\Program Files\GraphicsMagick-1.3.36-Q16\gm.exe" convert -average tmpimages\do_*.jpg avg.jpg
-   st="\"" + IMAGE_MAGIC_PATH + "\" convert -average " + TEMP_IMAGE_DIR + TEMP_IMAGE_PREFIX + "*.jpg " + Out_File_Name;
+    var st = "\"" + IMAGE_MAGIC_PATH + "\" convert -average " + TEMP_IMAGE_DIR + TEMP_IMAGE_PREFIX + "*.jpg " + Out_File_Name;
    logger(st);
    WshShell.Run (st,7, true);
 }
@@ -191,7 +191,6 @@ function clearImages()
     }
     //WScript.echo(s2); 
 
-   st = "";
    logger("Repeating images deleted: " + fileDeleteCount);
 }
 

--- a/makeAVI.js
+++ b/makeAVI.js
@@ -147,7 +147,7 @@ function prepareImageFolder()
 function makeAvi()
 {
     AVI_FILE = AVI_MOVIE_OUTPATH + OutBaseName + ".mp4";
-    st="\"" + FFMPEG_PATH + "\" -y -r 24 -f image2 -s 1920x1080 -i " + AVI_TEMPIMAGES_PATH + OutBaseName + "_%04d.jpg " + (AVI_OVERLAY_IMAGE != ""? "-i " + AVI_OVERLAY_IMAGE +" -filter_complex \"[0:v][1:v] overlay=0:0\" ":"") + "-vcodec libx264 -crf 25  -pix_fmt yuv420p " + AVI_FILE + "";        
+    var st = "\"" + FFMPEG_PATH + "\" -y -r 24 -f image2 -s 1920x1080 -i " + AVI_TEMPIMAGES_PATH + OutBaseName + "_%04d.jpg " + (AVI_OVERLAY_IMAGE != ""? "-i " + AVI_OVERLAY_IMAGE +" -filter_complex \"[0:v][1:v] overlay=0:0\" ":"") + "-vcodec libx264 -crf 25  -pix_fmt yuv420p " + AVI_FILE + "";
     logger(st);
     WshShell.Run (st,7, true);
 }
@@ -157,7 +157,7 @@ function makeAvi()
  **********************************************************************/
 function makeTempKeoImages()
 {
-    st="magick mogrify -crop 1x1080+959+0 -path "  + KEO_TEMP_FOLDER + " " + AVI_TEMPIMAGES_PATH + "*.jpg";
+    var st = "magick mogrify -crop 1x1080+959+0 -path "  + KEO_TEMP_FOLDER + " " + AVI_TEMPIMAGES_PATH + "*.jpg";
     logger(st);
     WshShell.Run (st,7, true);
 }
@@ -168,7 +168,7 @@ function makeTempKeoImages()
 function makeKeogramm()
 {
     KEOGRAM_FILE = AVI_MOVIE_OUTPATH + "keogram_" + OutBaseName + ".jpg";
-    st="magick montage -geometry +0+0 -tile x1 " + KEO_TEMP_FOLDER + "*.jpg " + KEOGRAM_FILE;
+    var st = "magick montage -geometry +0+0 -tile x1 " + KEO_TEMP_FOLDER + "*.jpg " + KEOGRAM_FILE;
     logger(st);
     WshShell.Run (st,7, true);
 }


### PR DESCRIPTION
## Summary
- Declare `st` locally when building ffmpeg and GraphicsMagick commands in `getAstroCamShot.js`.
- Scope `st` to each function generating commands in `makeAVI.js`.
- Remove unused global `st` assignment to avoid accidental globals.

## Testing
- `node --check getAstroCamShot.js`
- `node --check makeAVI.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2c2bf6a488325a29f33d37a6bc283