### PR TITLE
Add error handling for image folder preparation

### DIFF
--- a/makeAVI.js
+++ b/makeAVI.js
@@ -237,12 +237,16 @@ function headerOutput()
 
 parseCommandLineParameters();
 headerOutput();
-prepareImageFolder();
-if (createAVI) {
-	makeAvi();
+var prepStatus = prepareImageFolder();
+if (prepStatus !== 0) {
+        logger("prepareImageFolder failed with status " + prepStatus + ", exiting");
+        WScript.Quit(prepStatus);
 }
-if (createKeogram) 
+if (createAVI) {
+        makeAvi();
+}
+if (createKeogram)
 {
-	makeTempKeoImages();
-	makeKeogramm();
+        makeTempKeoImages();
+        makeKeogramm();
 }


### PR DESCRIPTION
## Summary
- Capture return value from `prepareImageFolder`
- Abort AVI/keogram creation if image folder setup fails

## Testing
- `node --check makeAVI.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2c42224d88325a0231671753f4c77